### PR TITLE
Fix: inconsistent use of caml_stat_* functions

### DIFF
--- a/src/eina_wrap.c
+++ b/src/eina_wrap.c
@@ -155,7 +155,7 @@ inline value* ml_register_value(value v)
 inline void ml_remove_value(value* data)
 {
         caml_remove_generational_global_root(data);
-        free(data);
+        caml_stat_free(data);
 }
 
 inline value copy_Eina_Rectangle(Eina_Rectangle* rect)
@@ -218,4 +218,3 @@ inline value copy_string_string(char** x)
         Store_field(v, 1, copy_string(x[1]));
         CAMLreturn(v);
 }
-

--- a/src/elm_entry_wrap.c
+++ b/src/elm_entry_wrap.c
@@ -3,19 +3,19 @@
 Evas_Object* ml_Elm_Entry_Item_Provider_Cb(
         void* data, Evas_Object* entry, const char* item)
 {
-      
+
         value* v_fun = (value*) data;
         value v_r = caml_callback2(*v_fun, (value) entry, copy_string(item));
         Evas_Object* r;
         if(v_r == Val_int(0)) r = NULL;
         else r = (Evas_Object*) Field(v_r, 0);
-      
+
         return r;
 }
 
 void ml_Elm_Entry_Filter_Cb(void* data, Evas_Object* entry, char** text)
 {
-      
+
         value* v_fun = (value*) data;
         value v_r = caml_callback2(*v_fun, (value) entry, copy_string(*text));
         free(*text);
@@ -25,7 +25,7 @@ void ml_Elm_Entry_Filter_Cb(void* data, Evas_Object* entry, char** text)
                 *text = caml_stat_alloc(strlen(text1) + 1);
                 strcpy(*text, text1);
         }
-      
+
 }
 
 inline Elm_Entry_Filter_Limit_Size
@@ -191,7 +191,7 @@ PREFIX value ml_elm_entry_filter_limit_size(
         else {
                 v = caml_alloc(1, 0);
                 Store_field(v, 0, copy_string(text));
-                free(text);
+                caml_stat_free(text);
         }
         CAMLreturn(v);
 }
@@ -209,7 +209,7 @@ PREFIX value ml_elm_entry_filter_accept_set(
         else {
                 v = caml_alloc(1, 0);
                 Store_field(v, 0, copy_string(text));
-                free(text);
+                caml_stat_free(text);
         }
         CAMLreturn(v);
 }
@@ -239,4 +239,3 @@ PREFIX value ml_elm_entry_anchor_hover_info_of_ptr(value v_ptr)
                 (Elm_Entry_Anchor_Hover_Info*) v_ptr;
         return copy_Elm_Entry_Anchor_Hover_Info(info);
 }
-


### PR DESCRIPTION
Hello. I'm doing a large-scale study of C stub sources on OPAM.

Your library makes use of the undocumented `caml_stat_*` functions, which currently are thin wrappers around `malloc`, `realloc`, and `free` from the C standard library. In future, the implementation of these functions [may change](https://github.com/ocaml/ocaml/pull/71), making them incompatible with `malloc` and breaking the code that abused the old undocumented semantics.

Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.