### PR TITLE
elm_gen{,grid,list}: add support for the reusable_content_get callback.

### DIFF
--- a/src/elm_gen.ml
+++ b/src/elm_gen.ml
@@ -4,5 +4,6 @@ type item_class = {
   func_content_get : Evas.obj -> string -> Evas.obj option;
   func_state_get : Evas.obj -> string -> bool;
   func_del : Evas.obj -> unit;
+  func_reusable_content_get : Evas.obj -> string -> Evas.obj -> Evas.obj option;
 }
 

--- a/src/elm_gen.mli
+++ b/src/elm_gen.mli
@@ -6,5 +6,6 @@ type item_class = {
   func_content_get : Evas.obj -> string -> Evas.obj option;
   func_state_get : Evas.obj -> string -> bool;
   func_del : Evas.obj -> unit;
+  func_reusable_content_get : Evas.obj -> string -> Evas.obj -> Evas.obj option;
 }
 

--- a/src/elm_gen_wrap.c
+++ b/src/elm_gen_wrap.c
@@ -50,3 +50,17 @@ void ml_Elm_Gen_Item_Del_Cb_free(void* data, Evas_Object* obj)
         CAMLreturn0;
 }
 
+/* Added in 1.18 without a useful documentation. */
+Evas_Object* ml_Elm_Gen_Item_Reusable_Content_Get_Cb(void* data, Evas_Object* obj, const char *part, Evas_Object *old)
+{
+        CAMLparam0();
+        CAMLlocal4(v_obj, v_part, v_old, v);
+        value* v_class = data;
+        v_obj = copy_Evas_Object(obj);
+        v_part = copy_string(part);
+        v_old = copy_Evas_Object(old);
+        v = caml_callback3(Field(*v_class, 5), v_obj, v_part, v_old);
+        CAMLreturnT(Evas_Object*,
+            (v == Val_int(0)) ? NULL : Evas_Object_val(Field(v, 0)));
+}
+

--- a/src/elm_gen_wrap.h
+++ b/src/elm_gen_wrap.h
@@ -12,5 +12,8 @@ PREFIX Eina_Bool ml_Elm_Gen_Item_State_Get_Cb(
 
 PREFIX void ml_Elm_Gen_Item_Del_Cb_free(void* data, Evas_Object* obj);
 
+/* Added in 1.18 without a useful documentation. */
+PREFIX Evas_Object* ml_Elm_Gen_Item_Reusable_Content_Get_Cb(void* data, Evas_Object* obj, const char *part, Evas_Object *old);
+
 #endif
 

--- a/src/elm_gengrid.ml.multi
+++ b/src/elm_gengrid.ml.multi
@@ -6,6 +6,9 @@ type item_class = Elm_gen.item_class = {
   func_content_get : Evas.obj -> string -> Evas.obj option;
   func_state_get : Evas.obj -> string -> bool;
   func_del : Evas.obj -> unit;
+(* BEGIN: 1.18 *)
+  func_reusable_content_get : Evas.obj -> string -> Evas.obj -> Evas.obj option;
+(* END *)
 }
 
 type item_field_type = Elm_genlist.item_field_type

--- a/src/elm_gengrid.mli.multi
+++ b/src/elm_gengrid.mli.multi
@@ -6,6 +6,9 @@ type item_class = Elm_gen.item_class = {
   func_content_get : Evas.obj -> string -> Evas.obj option;
   func_state_get : Evas.obj -> string -> bool;
   func_del : Evas.obj -> unit;
+(* BEGIN: 1.18 *)
+  func_reusable_content_get : Evas.obj -> string -> Evas.obj -> Evas.obj option;
+(* END *)
 }
 
 type item_scrollto_type = [`none | `_in | `top | `middle

--- a/src/elm_gengrid_wrap.c.multi
+++ b/src/elm_gengrid_wrap.c.multi
@@ -11,6 +11,7 @@ PREFIX void ml_Elm_Gengrid_Item_Class(
         c->func.content_get = ml_Elm_Gen_Item_Content_Get_Cb;
         c->func.state_get = ml_Elm_Gen_Item_State_Get_Cb;
         c->func.del = ml_Elm_Gen_Item_Del_Cb_free;
+        c->func.reusable_content_get = ml_Elm_Gen_Item_Reusable_Content_Get_Cb;
 
         value* v_data = ml_register_value(v);
 

--- a/src/elm_genlist.ml.multi
+++ b/src/elm_genlist.ml.multi
@@ -6,6 +6,9 @@ type item_class = Elm_gen.item_class = {
   func_content_get : Evas.obj -> string -> Evas.obj option;
   func_state_get : Evas.obj -> string -> bool;
   func_del : Evas.obj -> unit;
+(* BEGIN: 1.18 *)
+  func_reusable_content_get : Evas.obj -> string -> Evas.obj -> Evas.obj option;
+(* END *)
 }
 
 module AF = Autofun.Elm_genlist.F (struct

--- a/src/elm_genlist.mli.multi
+++ b/src/elm_genlist.mli.multi
@@ -6,6 +6,9 @@ type item_class = Elm_gen.item_class = {
   func_content_get : Evas.obj -> string -> Evas.obj option;
   func_state_get : Evas.obj -> string -> bool;
   func_del : Evas.obj -> unit;
+(* BEGIN: 1.18 *)
+  func_reusable_content_get : Evas.obj -> string -> Evas.obj -> Evas.obj option;
+(* END *)
 }
 
 type item_type = [`none | `tree | `group | `max]

--- a/src/elm_genlist_wrap.c.multi
+++ b/src/elm_genlist_wrap.c.multi
@@ -11,6 +11,7 @@ PREFIX void ml_Elm_Genlist_Item_Class(
         c->func.content_get = ml_Elm_Gen_Item_Content_Get_Cb;
         c->func.state_get = ml_Elm_Gen_Item_State_Get_Cb;
         c->func.del = ml_Elm_Gen_Item_Del_Cb_free;
+        c->func.reusable_content_get = ml_Elm_Gen_Item_Reusable_Content_Get_Cb;
 
         value* v_data = ml_register_value(v);
 


### PR DESCRIPTION
NB: I think this will break on <= 1.17 because of this bit in elm_gen{grid,list}_wrap.c.multi because of the line below but I don't know how to avoid the issue.

    c->func.reusable_content_get = ml_Elm_Gen_Item_Reusable_Content_Get_Cb;

Below is the current commit message.

This is a fairly new callback for genlists and gengrids. As far as I can
tell it makes it possible to avoid the creation of new item objects by
recycling an item that has recently gone of-screen.

I've found it very useful for prepending items to a genlist and I haven't
found drawbacks to it yet but I also haven't been able to understand why
it needed the flexibility of a callback instead of being always enabled
and my callbacks have always been very trivial:

    func_reusable_content_get = (fun _obj _part _old -> Some _old);

The callback receives an "old" object and returns an Evas.obj option. If
the return value is Some o, the object "o" will be used instead of creating
a new item object; if it is None, a new item object will be created.